### PR TITLE
chore: Use ExceptT for error handling

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -1,9 +1,9 @@
 import Export
 open Lean
 
-def semver := "2.0.0"
+def semver := "2.1.0"
 
-def main (args : List String) : IO Unit := do
+def main (args : List String) : IO UInt32 := do
   initSearchPath (← findSysroot)
   let (opts, args) := args.partition (fun s => s.startsWith "--" && s.length ≥ 3)
   let (imports, constants) := args.span (· != "--")
@@ -12,9 +12,14 @@ def main (args : List String) : IO Unit := do
   let constants := match constants.tail? with
     | some cs => cs.map fun c => Syntax.decodeNameLit ("`" ++ c) |>.get!
     | none    => env.constants.toList.map Prod.fst |>.filter (!·.isInternal)
-  M.run env do
+  let runResult ← M.run env do
     modify (fun st => { st with exportUnsafe := opts.any (· == "--export-unsafe") })
     IO.println semver
     for c in constants do
       modify (fun st => { st with noMDataExprs := {} })
       let _ ← dumpConstant c
+  match runResult with
+  | .ok _ => return 0
+  | e@(.error _) =>
+    IO.eprintln s!"{e}"
+    return 1

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.25.0-rc2
+leanprover/lean4:v4.26.0-rc2


### PR DESCRIPTION
As a triage to #8, adds some non-panic handling for the case where a constant to be dumped by name is not found in the environment. This should probably be considered an unrecoverable error in almost all scenarios, so it simply throws and terminates with an error message stating what declaration wasn't found, then terminates with a non-zero error code (1).

For the other disallowed export items (mvar, fvar, mdata for now) which are currently marked `unreachable`, they might as well be handled with a little bit more information and similarly fail immediately.