### PR TITLE
refine format: no arrays around definitions

### DIFF
--- a/Export.lean
+++ b/Export.lean
@@ -413,10 +413,10 @@ def exportMetadata : Json :=
   ]
   let exporterMeta := Json.mkObj [
     ("name", "lean4export"),
-    ("version", "3.0.0")
+    ("version", "3.1.0")
   ]
   let formatMeta := Json.mkObj [
-    ("version", "3.0.0")
+    ("version", "3.1.0")
   ]
 
   Json.mkObj [

--- a/Export.lean
+++ b/Export.lean
@@ -250,7 +250,7 @@ partial def dumpConstant (c : Name) : M Unit := do
     dumpDeps val.type
     dumpDeps val.value
     dumpObj [
-      ("defn", Json.mkObj [
+      ("def", Json.mkObj [
         ("name", ← dumpName val.name),
         ("levelParams", ← dumpUparams val.levelParams),
         ("type", ← dumpExpr val.type),

--- a/Export.lean
+++ b/Export.lean
@@ -231,7 +231,8 @@ partial def dumpExpr (e : Expr) : M Nat := do
     dumpExprAux <| ← if (← get).exportMData then pure e else aux e
 
 partial def dumpConstant (c : Name) : M Unit := do
-  let declar := ((← read).env.find? c).get!
+  let some declar := (← read).env.find? c
+    | panic! s!"Constant {c} not found in environment."
   if (declar.isUnsafe && !(← get).exportUnsafe) || (← get).visitedConstants.contains c then
     return
   modify fun st => { st with visitedConstants := st.visitedConstants.insert c }
@@ -380,9 +381,9 @@ partial def dumpConstant (c : Name) : M Unit := do
       ]
     dumpObj [
       ("inductive", Json.mkObj [
-        ("inductiveVals", inductiveValsJson.toJson),
-        ("constructorVals", ctorValsJson.toJson),
-        ("recursorVals", recursorValsJson.toJson),
+        ("types", inductiveValsJson.toJson),
+        ("ctors", ctorValsJson.toJson),
+        ("recs", recursorValsJson.toJson),
       ])
     ]
   | .ctorInfo val => dumpConstant val.induct
@@ -403,5 +404,28 @@ where
   dumpObj (fields : List (String × Json)) : M Unit :=
     IO.println <| Json.mkObj fields |>.compress
 
-
 end
+
+def exportMetadata : Json :=
+  let leanMeta := Json.mkObj [
+    ("version", versionString),
+    ("githash", githash)
+  ]
+  let exporterMeta := Json.mkObj [
+    ("name", "lean4export"),
+    ("version", "3.0.0")
+  ]
+  let formatMeta := Json.mkObj [
+    ("version", "3.0.0")
+  ]
+
+  Json.mkObj [
+    ("meta", Json.mkObj [
+      ("exporter", exporterMeta),
+      ("lean", leanMeta),
+      ("format", formatMeta)
+    ])
+  ]
+
+def dumpMetadata : M Unit := do
+  IO.println exportMetadata.compress

--- a/Main.lean
+++ b/Main.lean
@@ -1,27 +1,6 @@
 import Export
 open Lean
 
-def exportMetadata : Json :=
-  let leanMeta := Json.mkObj [
-    ("version", versionString),
-    ("githash", githash)
-  ]
-  let exporterMeta := Json.mkObj [
-    ("name", "lean4export"),
-    ("version", "3.0.0")
-  ]
-  let formatMeta := Json.mkObj [
-    ("version", "3.0.0")
-  ]
-
-  Json.mkObj [
-    ("meta", Json.mkObj [
-      ("exporter", exporterMeta),
-      ("lean", leanMeta),
-      ("format", formatMeta)
-    ])
-  ]
-
 def main (args : List String) : IO Unit := do
   initSearchPath (← findSysroot)
   let (opts, args) := args.partition (fun s => s.startsWith "--" && s.length ≥ 3)
@@ -33,7 +12,7 @@ def main (args : List String) : IO Unit := do
     | none    => env.constants.toList.map Prod.fst |>.filter (!·.isInternal)
   M.run env do
     let _ ← initState env opts
-    IO.println exportMetadata.compress
+    dumpMetadata
     for c in constants do
       modify (fun st => { st with noMDataExprs := {} })
       dumpConstant c

--- a/Test.lean
+++ b/Test.lean
@@ -156,7 +156,7 @@ info: {"in":1,"str":{"pre":0,"str":"id"}}
 {"forallE":{"binderInfo":"implicit","body":3,"name":3,"type":0},"ie":4}
 {"ie":5,"lam":{"binderInfo":"default","body":1,"name":4,"type":1}}
 {"ie":6,"lam":{"binderInfo":"implicit","body":5,"name":3,"type":0}}
-{"def":[{"all":[1],"hints":{"regular":1},"levelParams":[2],"name":1,"safety":"safe","type":4,"value":6}]}
+{"def":{"all":[1],"hints":{"regular":1},"levelParams":[2],"name":1,"safety":"safe","type":4,"value":6}}
 -/
 #guard_msgs in
 #eval run <| do

--- a/Test.lean
+++ b/Test.lean
@@ -74,7 +74,8 @@ info: {"in":1,"str":{"pre":0,"str":"Prod"}}
 #guard_msgs in
 #eval runEmpty <| dumpExpr (.lit (.natVal 100000000000000023456789))
 
-/-- info: {"in":1,"str":{"pre":0,"str":"Nat"}}
+/--
+info: {"in":1,"str":{"pre":0,"str":"Nat"}}
 {"il":1,"succ":0}
 {"ie":0,"sort":1}
 {"in":2,"str":{"pre":1,"str":"zero"}}
@@ -123,7 +124,7 @@ info: {"in":1,"str":{"pre":0,"str":"Prod"}}
 {"ie":33,"lam":{"binderInfo":"default","body":32,"name":10,"type":16}}
 {"ie":34,"lam":{"binderInfo":"default","body":33,"name":9,"type":7}}
 {"ie":35,"lam":{"binderInfo":"default","body":34,"name":7,"type":4}}
-{"inductive":{"constructorVals":[{"cidx":0,"induct":1,"isUnsafe":false,"levelParams":[],"name":2,"numFields":0,"numParams":0,"type":1},{"cidx":1,"induct":1,"isUnsafe":false,"levelParams":[],"name":3,"numFields":1,"numParams":0,"type":2}],"inductiveVals":[{"all":[1],"ctors":[2,3],"isRec":true,"isReflexive":false,"isUnsafe":false,"levelParams":[],"name":1,"numIndices":0,"numNested":0,"numParams":0,"type":0}],"recursorVals":[{"all":[1],"isUnsafe":false,"k":false,"levelParams":[6],"name":5,"numIndices":0,"numMinors":2,"numMotives":1,"numParams":0,"rules":[{"ctor":2,"nfields":0,"rhs":24},{"ctor":3,"nfields":1,"rhs":35}],"type":21}]}}
+{"inductive":{"ctors":[{"cidx":0,"induct":1,"isUnsafe":false,"levelParams":[],"name":2,"numFields":0,"numParams":0,"type":1},{"cidx":1,"induct":1,"isUnsafe":false,"levelParams":[],"name":3,"numFields":1,"numParams":0,"type":2}],"recs":[{"all":[1],"isUnsafe":false,"k":false,"levelParams":[6],"name":5,"numIndices":0,"numMinors":2,"numMotives":1,"numParams":0,"rules":[{"ctor":2,"nfields":0,"rhs":24},{"ctor":3,"nfields":1,"rhs":35}],"type":21}],"types":[{"all":[1],"ctors":[2,3],"isRec":true,"isReflexive":false,"isUnsafe":false,"levelParams":[],"name":1,"numIndices":0,"numNested":0,"numParams":0,"type":0}]}}
 {"ie":36,"natVal":"100000000000000023456789"}
 -/
 #guard_msgs in
@@ -237,7 +238,7 @@ info: {"in":1,"str":{"pre":0,"str":"List"}}
 {"ie":53,"lam":{"binderInfo":"default","body":52,"name":12,"type":17}}
 {"ie":54,"lam":{"binderInfo":"default","body":53,"name":10,"type":14}}
 {"ie":55,"lam":{"binderInfo":"default","body":54,"name":3,"type":0}}
-{"inductive":{"constructorVals":[{"cidx":0,"induct":1,"isUnsafe":false,"levelParams":[2],"name":4,"numFields":0,"numParams":1,"type":5},{"cidx":1,"induct":1,"isUnsafe":false,"levelParams":[2],"name":5,"numFields":2,"numParams":1,"type":12}],"inductiveVals":[{"all":[1],"ctors":[4,5],"isRec":true,"isReflexive":false,"isUnsafe":false,"levelParams":[2],"name":1,"numIndices":0,"numNested":0,"numParams":1,"type":1}],"recursorVals":[{"all":[1],"isUnsafe":false,"k":false,"levelParams":[9,2],"name":8,"numIndices":0,"numMinors":2,"numMotives":1,"numParams":1,"rules":[{"ctor":4,"nfields":0,"rhs":39},{"ctor":5,"nfields":2,"rhs":55}],"type":35}]}}
+{"inductive":{"ctors":[{"cidx":0,"induct":1,"isUnsafe":false,"levelParams":[2],"name":4,"numFields":0,"numParams":1,"type":5},{"cidx":1,"induct":1,"isUnsafe":false,"levelParams":[2],"name":5,"numFields":2,"numParams":1,"type":12}],"recs":[{"all":[1],"isUnsafe":false,"k":false,"levelParams":[9,2],"name":8,"numIndices":0,"numMinors":2,"numMotives":1,"numParams":1,"rules":[{"ctor":4,"nfields":0,"rhs":39},{"ctor":5,"nfields":2,"rhs":55}],"type":35}],"types":[{"all":[1],"ctors":[4,5],"isRec":true,"isReflexive":false,"isUnsafe":false,"levelParams":[2],"name":1,"numIndices":0,"numNested":0,"numParams":1,"type":1}]}}
 -/
 #guard_msgs in
 #eval run <| do

--- a/format_ndjson.md
+++ b/format_ndjson.md
@@ -23,7 +23,7 @@ Initial metadata object
 
 followed by a sequence of primitives with integer tags (Name, Level, or Expr) and declartions (axiom, definition, theorem, opaque, quot, inductive, constructor, recursor), where related elements of an inductive or mutual inductive declaration (the inductive specifications, constructors, and recursors) are grouped together.
 
-The export format contains information that is redundant and would likely be ignored or only validated by an fulll external checker (such as the types of recursors). These are included for the benefit of other tools that want all constants with their types (e.g. dependency analysis tools).
+The export format contains information that is redundant and would likely be ignored or only validated by a full external checker (such as the types of recursors). These are included for the benefit of other tools that want all constants with their types (e.g. dependency analysis tools).
 
 The construction of these elements is as described below (line breaks were added for readability; note that the NDJSON format requires these JSON objects to be rendered without any line breaks):
 
@@ -266,7 +266,7 @@ Expr.mdata
 
 ### Quotients
 
-NB: The official Lean kernel uses the field-less constructor `Lean.Declaration.quotDecl : Lean.Declaration` as the input to declare the quotient declaratoins, and then adds the four declarations that make up the quotient package to the environment. The export format includes the data of these generated declarations for convenience. 
+NB: The official Lean kernel uses the field-less constructor `Lean.Declaration.quotDecl : Lean.Declaration` as the input to declare the quotient declarations, and then adds the four declarations that make up the quotient package to the environment. The export format includes the data of these generated declarations for convenience. 
 
 ```
 {
@@ -281,7 +281,7 @@ NB: The official Lean kernel uses the field-less constructor `Lean.Declaration.q
 
 ### Inductive Declaration:
 
-NB: The official lean Kernel expect a `Lean.Declaration.inductDecl`, which contains a (mutual) group of inductive declarations with their constructors. From that the kernel deries the recursors, and informational fields like `isRec`, `isReflexive` or `cidx`. The export format includes the data of these generated declarations for convenience. 
+NB: The official Lean kernel expect a `Lean.Declaration.inductDecl`, which contains a (mutual) group of inductive declarations with their constructors. From that the kernel deries the recursors, and informational fields like `isRec`, `isReflexive` or `cidx`. The export format includes the data of these generated declarations for convenience. 
 
 
 ```

--- a/format_ndjson.md
+++ b/format_ndjson.md
@@ -1,6 +1,6 @@
 # Lean 4 export format: version 3.1.0
 
-An exported `.ndjson` file will begin with an initial `meta` object which includes version info for the exporter, lean, and export format:
+An exported `.ndjson` file will begin with an initial `meta` object which includes version info for the exporter, Lean, and export format:
 
 Initial metadata object
 ```
@@ -21,7 +21,7 @@ Initial metadata object
 }
 ```
 
-followed by a sequence of primitives with integer tags (Name, Level, or Expr) and declartions (axiom, definition, theorem, opaque, quot, inductive, constructor, recursor), where related elements of an inductive or mutual inductive declaration (the inductive specifications, constructors, and recursors) are grouped together.
+followed by a sequence of primitives with integer tags (Name, Level, or Expr) and declarations (axiom, definition, theorem, opaque, quot, inductive, constructor, recursor), where related elements of an inductive or mutual inductive declaration (the inductive specifications, constructors, and recursors) are grouped together.
 
 The export format contains information that is redundant and would likely be ignored or only validated by a full external checker (such as the types of recursors). These are included for the benefit of other tools that want all constants with their types (e.g. dependency analysis tools).
 
@@ -281,8 +281,7 @@ NB: The official Lean kernel uses the field-less constructor `Lean.Declaration.q
 
 ### Inductive Declaration:
 
-NB: The official Lean kernel expect a `Lean.Declaration.inductDecl`, which contains a (mutual) group of inductive declarations with their constructors. From that the kernel deries the recursors, and informational fields like `isRec`, `isReflexive` or `cidx`. The export format includes the data of these generated declarations for convenience. 
-
+NB: The official Lean kernel expects a `Lean.Declaration.inductDecl`, which contains a (mutual) group of inductive declarations with their constructors. From that the kernel derives the recursors, and informational fields like `isRec`, `isReflexive` or `cidx`. The export format includes the data of these generated declarations for convenience. 
 
 ```
 {

--- a/format_ndjson.md
+++ b/format_ndjson.md
@@ -287,9 +287,9 @@ NB: The official lean Kernel expect a `Lean.Declaration.inductDecl`, which conta
 ```
 {
     "inductive": {
-        "inductiveVals": Array<InductiveVal>,
-        "constructorVals": Array<ConstructorVal>,
-        "recursorVals": Array<RecursorVal>
+        "types": Array<InductiveVal>,
+        "ctors": Array<ConstructorVal>,
+        "recs": Array<RecursorVal>
     }
 }
 ```

--- a/format_ndjson.md
+++ b/format_ndjson.md
@@ -225,7 +225,7 @@ Expr.mdata
 ### Definition
 ```
 {
-    "defn": {
+    "def": {
         "name": integer,
         "levelParams": Array<integer>,
         "type": integer,


### PR DESCRIPTION
This PR refines the NDJSON format based on the discussion in #14, and removes the grouping of definitions, theorem or opaques in arrays, simplifying the format and the exporter code.

This bumps the format to 3.1.0.

I took the liberty of polishing some field names (no need to include `Info`, since we are anyways not following `ConstantInfo` directly), and added more comments and information to the format description.
