### PR TITLE
fix import name generation

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -5,7 +5,7 @@ def main (args : List String) : IO Unit := do
   initSearchPath (← findSysroot)
   let (opts, args) := args.partition (fun s => s.startsWith "--" && s.length ≥ 3)
   let (imports, constants) := args.span (· != "--")
-  let imports := imports.toArray.map fun mod => { module := Syntax.decodeNameLit ("`" ++ mod) |>.get! }
+  let imports := imports.toArray.map fun mod => { module := mod.toName }
   let env ← importModules imports {}
   let constants := match constants.tail? with
     | some cs => cs.map fun c => Syntax.decodeNameLit ("`" ++ c) |>.get!


### PR DESCRIPTION
this potentially fixes handling of filenames starting with number, for more details see https://github.com/leanprover/comparator/issues/17
