### PR TITLE
feat: export `Quot`-package together 

### DIFF
--- a/Export.lean
+++ b/Export.lean
@@ -286,21 +286,21 @@ partial def dumpConstant (c : Name) : M Unit := do
         ("all", ← dumpNames val.all)
       ])
     ]
-  | .quotInfo val =>
-    -- Always dump full Quot package (also pulls in Eq)
-    dumpConstant ``Quot
-    dumpConstant ``Quot.mk
-    dumpConstant ``Quot.lift
-    dumpConstant ``Quot.ind
-    dumpConstant ``Quot.sound
-    dumpObj [
-      ("quot", .mkObj [
-        ("name", ← dumpName val.name),
-        ("levelParams", ← dumpUparams val.levelParams),
-        ("type", ← dumpExpr val.type),
-        ("kind", val.kind.toJson)
-      ])
-    ]
+  | .quotInfo _ =>
+    -- Always dump full Quot package in the sensible order
+    dumpConstant ``Eq
+    for c in [`Quot, ``Quot.lift, ``Quot.ind, ``Quot.sound] do
+      let some (.quotInfo val) := (← read).env.find? c
+        | panic! s!"Constant {c} not found in environment."
+      modify fun st => { st with visitedConstants := st.visitedConstants.insert c }
+      dumpObj [
+        ("quot", .mkObj [
+          ("name", ← dumpName val.name),
+          ("levelParams", ← dumpUparams val.levelParams),
+          ("type", ← dumpExpr val.type),
+          ("kind", val.kind.toJson)
+        ])
+      ]
   | .inductInfo baseIndVal => do
     let mut indVals := #[]
     let mut ctorVals := #[]

--- a/Export.lean
+++ b/Export.lean
@@ -289,7 +289,7 @@ partial def dumpConstant (c : Name) : M Unit := do
   | .quotInfo _ =>
     -- Always dump full Quot package in the sensible order
     dumpConstant ``Eq
-    for c in [`Quot, ``Quot.lift, ``Quot.ind] do
+    for c in [`Quot, ``Quot.mk, ``Quot.lift, ``Quot.ind] do
       let some (.quotInfo val) := (← read).env.find? c
         | panic! s!"Constant {c} not found in environment."
       modify fun st => { st with visitedConstants := st.visitedConstants.insert c }

--- a/Export.lean
+++ b/Export.lean
@@ -287,6 +287,7 @@ partial def dumpConstant (c : Name) : M Unit := do
       ])
     ]
   | .quotInfo val =>
+    dumpConstant ``Eq
     dumpDeps val.type
     dumpObj [
       ("quot", .mkObj [

--- a/Export.lean
+++ b/Export.lean
@@ -289,7 +289,7 @@ partial def dumpConstant (c : Name) : M Unit := do
   | .quotInfo _ =>
     -- Always dump full Quot package in the sensible order
     dumpConstant ``Eq
-    for c in [`Quot, ``Quot.lift, ``Quot.ind, ``Quot.sound] do
+    for c in [`Quot, ``Quot.lift, ``Quot.ind] do
       let some (.quotInfo val) := (← read).env.find? c
         | panic! s!"Constant {c} not found in environment."
       modify fun st => { st with visitedConstants := st.visitedConstants.insert c }

--- a/Export.lean
+++ b/Export.lean
@@ -287,8 +287,12 @@ partial def dumpConstant (c : Name) : M Unit := do
       ])
     ]
   | .quotInfo val =>
-    dumpConstant ``Eq
-    dumpDeps val.type
+    -- Always dump full Quot package (also pulls in Eq)
+    dumpConstant ``Quot
+    dumpConstant ``Quot.mk
+    dumpConstant ``Quot.lift
+    dumpConstant ``Quot.ind
+    dumpConstant ``Quot.sound
     dumpObj [
       ("quot", .mkObj [
         ("name", ← dumpName val.name),

--- a/Test.lean
+++ b/Test.lean
@@ -310,7 +310,22 @@ info: Eq
 Eq.refl
 Eq.rec
 Quot
+Quot.mk
 Quot.lift
+Quot.ind
+-/
+#guard_msgs in
+#eval runParserTest do
+  dumpConstant `Quot.mk
+
+/--
+info: Eq
+Eq.refl
+Eq.rec
+Quot
+Quot.mk
+Quot.lift
+Quot.ind
 -/
 #guard_msgs in
 #eval runParserTest do


### PR DESCRIPTION
This PR exports `Eq` and the other `Quot` declarations with any of the four `Quot`-related declaration. This is for the benefit of checkers who want to create the whole `Quot` package (including `Quot.lift`, which uses `Eq`) as soon as `Quot` is added, and to allow such checkers to process pruned environments that may happen to exclude `Quot.lift`.
