### PR TITLE
parser: fail upon duplicate declarations

### DIFF
--- a/Export/Parse.lean
+++ b/Export/Parse.lean
@@ -76,6 +76,8 @@ def addRecursorRule (ridx : Nat) (r : Lean.RecursorRule) : M Unit := do
 
 @[inline]
 def addConst (name : Lean.Name) (d : Lean.ConstantInfo) : M Unit := do
+  if (← get).constMap.contains name then
+    fail s!"Duplicate declaration: {name}"
   modify fun s => {
     s with
       constMap := s.constMap.insert name d


### PR DESCRIPTION
While most attacks involving duplicate declarations that actually prove
False would still be caught if one delaration is simply ignored, it
seems safer to catch this early and for all users of the parser. At
least until someone comes up with a use case for duplicate declarations
in the same file.
